### PR TITLE
Improve default formatting and remove overrides

### DIFF
--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -27,8 +27,8 @@
   <!-- Page size? Accepted values: 
  a0paper, a1paper, a2paper, a3paper, a4paper, a5paper, a6paper, b0paper, b1paper, b2paper, b3paper, b4paper, b5paper, b6paper, c0paper, c1paper, c2paper, c3paper, c4paper, c5paper, c6paper, b0j, b1j, b2j, b3j, b4j, b5j, b6j, ansiapaper, ansibpaper, ansicpaper, ansidpaper, ansiepaper, letterpaper, executivepaper, legalpaper -->
   <xsl:param name="pageSize">a4paper</xsl:param>
-  <!-- Use layout for double-sided printing? Accepted values = 0 (No), 1 (Yes) -->
-  <xsl:param name="doubleSided">1</xsl:param>
+  <!-- Use layout for facing pages? Accepted values = 0 (single pages), 1 (facing pages) -->
+  <xsl:param name="facingLayout">0</xsl:param>
   <!-- Setting the size of the margins, in cm -->
   <xsl:param name="marginInner"></xsl:param>
   <xsl:param name="marginOuter"></xsl:param>
@@ -161,7 +161,7 @@
 
 
   <xsl:template match="/">
-    <xsl:text>\documentclass[</xsl:text><xsl:value-of select="$pageSize"/><xsl:if test="$doubleSided = '1'"><xsl:text>,twoside</xsl:text></xsl:if><xsl:text>]{article}
+    <xsl:text>\documentclass[</xsl:text><xsl:value-of select="$pageSize"/><xsl:if test="$facingLayout = '1'"><xsl:text>,twoside</xsl:text></xsl:if><xsl:text>]{article}
     \usepackage[oldstyle,proportional]{libertine}
     \usepackage{fontspec}
     \usepackage{microtype}

--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -111,7 +111,7 @@
 
 
   <!-- How to display the contents of tei:head ? -->
-  <!-- Should it be in bold? Accepted values: 1 for italic, 2 for bold -->
+  <!-- Should it be in bold? Accepted values: 1 for italic, 2 for bold, 3 for small caps -->
   <xsl:param name="headStyle">1</xsl:param>
   <!-- vSpace before and after each tei:head, in cm -->
   <xsl:param name="headStylevSpaceBefore">0.5</xsl:param>
@@ -320,6 +320,9 @@
     </xsl:if>
     <xsl:if test="$headStyle = '2'">
       <xsl:text>bf</xsl:text>
+    </xsl:if>
+    <xsl:if test="$headStyle = '3'">
+      <xsl:text>sc</xsl:text>
     </xsl:if>
     <xsl:text>{#1}\vspace{</xsl:text>
     <xsl:value-of select="$headStylevSpaceAfter"/>

--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -327,10 +327,6 @@
       
     \begin{document}
   </xsl:text>
-    <xsl:if test="$pageNumFirstPage = '0'">
-      <xsl:text>
-      \thispagestyle{empty}</xsl:text>
-    </xsl:if>
     <xsl:text>
       \sidenotemargin{</xsl:text><xsl:value-of select="$sideNoteLocation"
       /><xsl:text>} 
@@ -343,6 +339,10 @@
     <!-- Printing (or not) the document title -->
     <xsl:if test="$printTitle != '0'">
       \maketitle
+    </xsl:if>
+    <xsl:if test="$pageNumFirstPage = '0'">
+      <xsl:text>
+      \thispagestyle{empty}</xsl:text>
     </xsl:if>
     <xsl:if test="$printListWit != '0'">
       <xsl:if test="//tei:listWit">

--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -93,9 +93,9 @@
   <!-- do you want to print the document title? Yes if value is different from 0 -->
   <xsl:param name="printTitle">1</xsl:param>
   <!-- How big should we print the title? Accepted values are large, Large, LARGE, huge, Huge.  Those sizes are relative to the normal font size in the document.  For more information see: http://jacques-andre.fr/fontex/taille.pdf -->
-  <xsl:param name="printTitleSize">Large</xsl:param>
-  <!-- Should we print the title in small caps or caps? Accepted values: 0 (no formatting), smallcaps and caps -->
-  <xsl:param name="printTitleStyle">smallcaps</xsl:param>
+  <xsl:param name="printTitleSize"></xsl:param>
+  <!-- Should we print the title in small caps or caps? Accepted values: smallcaps and caps -->
+  <xsl:param name="printTitleStyle"></xsl:param>
 
 
 
@@ -192,6 +192,8 @@
     </xsl:if>
     <xsl:text>
     \usepackage[</xsl:text><xsl:value-of select="$baseFontSize"/><xsl:text>pt]{extsizes}</xsl:text>
+
+    <!-- Set margins -->
     <xsl:if test="$marginBinding != '' or $marginInner != '' or $marginOuter != '' or $marginTop != '' or $marginBottom != ''">
     <xsl:text>
       \usepackage[</xsl:text>
@@ -219,6 +221,7 @@
       </xsl:if>
       <xsl:text>]{geometry}</xsl:text>
     </xsl:if>
+
     <!-- Fancy headers and footers -->
     <xsl:text>
     \usepackage{fancyhdr} 
@@ -322,6 +325,22 @@
     <xsl:text>}
       \date{}
     </xsl:text>
+    
+    <!-- Title styling -->
+    <xsl:if test="$printTitleStyle != '' or $printTitleSize != ''">
+      <xsl:text>\usepackage{titling}
+      \pretitle{\begin{center}</xsl:text>
+      <xsl:choose>
+        <xsl:when test="$printTitleSize != ''"><xsl:text>\</xsl:text><xsl:value-of select="$printTitleSize"/></xsl:when>
+        <xsl:otherwise><xsl:text>\Large</xsl:text></xsl:otherwise>
+      </xsl:choose>
+      <xsl:choose>
+        <xsl:when test="$printTitleStyle = 'smallcaps'"><xsl:text>\scshape</xsl:text></xsl:when>
+        <xsl:when test="$printTitleStyle = 'caps'"><xsl:text>\MakeUppercase</xsl:text></xsl:when>
+      </xsl:choose>
+      <xsl:text>}</xsl:text>
+    </xsl:if>
+    
     <xsl:text>
     % Basic workaround for broken \section functionality in reledmac
     \newcommand{\TEIsection}[1]{\vspace{</xsl:text>

--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -27,12 +27,14 @@
   <!-- Page size? Accepted values: 
  a0paper, a1paper, a2paper, a3paper, a4paper, a5paper, a6paper, b0paper, b1paper, b2paper, b3paper, b4paper, b5paper, b6paper, c0paper, c1paper, c2paper, c3paper, c4paper, c5paper, c6paper, b0j, b1j, b2j, b3j, b4j, b5j, b6j, ansiapaper, ansibpaper, ansicpaper, ansidpaper, ansiepaper, letterpaper, executivepaper, legalpaper -->
   <xsl:param name="pageSize">a4paper</xsl:param>
+  <!-- Use layout for double-sided printing? Accepted values = 0 (No), 1 (Yes) -->
+  <xsl:param name="doubleSided">1</xsl:param>
   <!-- Setting the size of the margins, in cm -->
-  <xsl:param name="marginInner">3</xsl:param>
-  <xsl:param name="marginOuter">3</xsl:param>
-  <xsl:param name="marginTop">3</xsl:param>
-  <xsl:param name="marginBottom">3</xsl:param>
-  <xsl:param name="marginBinding">0.5</xsl:param>
+  <xsl:param name="marginInner"></xsl:param>
+  <xsl:param name="marginOuter"></xsl:param>
+  <xsl:param name="marginTop"></xsl:param>
+  <xsl:param name="marginBottom"></xsl:param>
+  <xsl:param name="marginBinding"></xsl:param>
 
 
   <!-- Set main language (useful for hyphenation rules)  -->
@@ -148,7 +150,7 @@
   <!-- Do you want to add a prologue to the index nominum? -->
   <xsl:param name="idxNomPrologue"/>
   <!-- Which title do you want for the index nominum? -->
-  <xsl:param name="idxNomTitle">My Index Nominum</xsl:param>
+  <xsl:param name="idxNomTitle">Index Nominum</xsl:param>
   <!-- Do you want to add an index locorum? 0 = no, 1 = yes-->
   <xsl:param name="idxLoc">1</xsl:param>
   <!-- Do you want to add a prologue to the index nominum? -->
@@ -159,7 +161,7 @@
 
 
   <xsl:template match="/">
-    <xsl:text>\documentclass{article}
+    <xsl:text>\documentclass[</xsl:text><xsl:value-of select="$pageSize"/><xsl:if test="$doubleSided = '1'"><xsl:text>,twoside</xsl:text></xsl:if><xsl:text>]{article}
     \usepackage[oldstyle,proportional]{libertine}
     \usepackage{fontspec}
     \usepackage{microtype}
@@ -175,32 +177,48 @@
       <xsl:text>cm}</xsl:text>
     </xsl:if>
     <xsl:if test="$idxNom = '1' or $idxLoc = '1'">
-      <xsl:text>
-        \usepackage[innote]{indextools}
+      <xsl:text>\usepackage[innote]{indextools}
       </xsl:text>
       <!--    \indexsetup{}  -->
       <xsl:if test="$idxNom = '1'">
-        <xsl:text>
-          \makeindex[title={</xsl:text>
+        <xsl:text>\makeindex[title={</xsl:text>
         <xsl:value-of select="$idxNomTitle"/>
         <xsl:text>},name=nominum]</xsl:text>
       </xsl:if>
       <xsl:if test="$idxLoc = '1'">
-        <xsl:text>
-          \makeindex[title={</xsl:text><xsl:value-of select="$idxLocTitle"/>
+        <xsl:text>\makeindex[title={</xsl:text><xsl:value-of select="$idxLocTitle"/>
         <xsl:text>},name=locorum]</xsl:text>
       </xsl:if>
     </xsl:if>
     <xsl:text>
-      \usepackage[</xsl:text><xsl:value-of select="$baseFontSize"/><xsl:text>pt]{extsizes}</xsl:text>
+    \usepackage[</xsl:text><xsl:value-of select="$baseFontSize"/><xsl:text>pt]{extsizes}</xsl:text>
+    <xsl:if test="$marginBinding != '' or $marginInner != '' or $marginOuter != '' or $marginTop != '' or $marginBottom != ''">
     <xsl:text>
-      \usepackage[</xsl:text><xsl:value-of select="$pageSize"
-      /><xsl:text>, twoside, bindingoffset=</xsl:text><xsl:value-of select="$marginBinding"
-      /><xsl:text>cm, inner=</xsl:text><xsl:value-of select="$marginInner"
-      /><xsl:text>cm, outer=</xsl:text><xsl:value-of select="$marginOuter"
-      /><xsl:text>cm, top=</xsl:text><xsl:value-of select="$marginTop"
-      /><xsl:text>cm, bottom=</xsl:text><xsl:value-of select="$marginBottom"/><xsl:text>cm]{geometry} </xsl:text>
-    
+      \usepackage[</xsl:text>
+      <xsl:if test="$marginBinding != ''">
+        <xsl:text>bindingoffset=</xsl:text>
+        <xsl:value-of select="$marginBinding"/>
+        <xsl:text>cm,</xsl:text>
+      </xsl:if>
+      <xsl:if test="$marginBinding != ''">
+        <xsl:text>inner=</xsl:text>
+        <xsl:value-of select="$marginInner"/>
+        <xsl:text>cm,</xsl:text>
+      </xsl:if><xsl:if test="$marginOuter != ''">
+        <xsl:text>outer=</xsl:text>
+        <xsl:value-of select="$marginOuter"/>
+        <xsl:text>cm,</xsl:text>
+      </xsl:if><xsl:if test="$marginTop != ''">
+        <xsl:text>top=</xsl:text>
+        <xsl:value-of select="$marginTop"/>
+        <xsl:text>cm,</xsl:text>
+      </xsl:if><xsl:if test="$marginBottom != ''">
+        <xsl:text>bottom=</xsl:text>
+        <xsl:value-of select="$marginBottom"/>
+        <xsl:text>cm</xsl:text>
+      </xsl:if>
+      <xsl:text>]{geometry}</xsl:text>
+    </xsl:if>
     <!-- Fancy headers and footers -->
     <xsl:text>
     \usepackage{fancyhdr} 
@@ -335,7 +353,7 @@
     <xsl:text>
       \sidenotemargin{</xsl:text><xsl:value-of select="$sideNoteLocation"
       /><xsl:text>} 
-        \pagenumbering{</xsl:text><xsl:value-of select="$pageNumberingStyle"/><xsl:text>} </xsl:text>
+      \pagenumbering{</xsl:text><xsl:value-of select="$pageNumberingStyle"/><xsl:text>} </xsl:text>
     <xsl:if test="$fromPage != '0'">
       <xsl:text>
         \setcounter{page}{</xsl:text><xsl:value-of select="$fromPage"
@@ -358,25 +376,25 @@
       \beginnumbering </xsl:text>
     <xsl:apply-templates select="/tei:TEI/tei:text/tei:body"/>
     <xsl:text>
-      \endnumbering </xsl:text>
+    \endnumbering </xsl:text>
     <xsl:if test="$idxNom = '1'">
       <xsl:if test="$idxNomPrologue != ''"
           ><xsl:text>
-        \indexprologue{\small </xsl:text><xsl:value-of
+  \indexprologue{\small </xsl:text><xsl:value-of
           select="$idxNomPrologue"/><xsl:text>} </xsl:text></xsl:if>
       <xsl:text>
-            \printindex[nominum]</xsl:text>
+  \printindex[nominum]</xsl:text>
     </xsl:if>
     <xsl:if test="$idxLoc = '1'">
       <xsl:if test="$idxLocPrologue != ''">
         <xsl:text>
-        \indexprologue{\small </xsl:text><xsl:value-of select="$idxLocPrologue"
+  \indexprologue{\small </xsl:text><xsl:value-of select="$idxLocPrologue"
         /><xsl:text>} </xsl:text></xsl:if>
       <xsl:text>
-        \printindex[locorum]</xsl:text>
+  \printindex[locorum]</xsl:text>
     </xsl:if>
     <xsl:text>
-       \end{document}</xsl:text>
+\end{document}</xsl:text>
   </xsl:template>
 
   <!-- Prints div heads as a Chapter -->
@@ -1594,7 +1612,8 @@
     <xsl:apply-templates/>
     <!--<xsl:value-of select='normalize-space()'/>--> &amp; </xsl:template>
   <xsl:template match="tei:listWit">
-    <xsl:text>\begin{description}</xsl:text>
+    <xsl:text>
+      \begin{description}</xsl:text>
     <xsl:apply-templates/>
     <xsl:text>
       \end{description}</xsl:text>

--- a/tei2latex_final.xslt
+++ b/tei2latex_final.xslt
@@ -165,7 +165,9 @@
     \usepackage{microtype}
     \usepackage{polyglossia}
     \usepackage{bookmark}
-    \hypersetup{pdfborder={0 0 0}}
+    \hypersetup{pdftitle={</xsl:text><xsl:value-of select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/><xsl:text>},
+                pdfauthor={</xsl:text><xsl:value-of select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:text>},
+                pdfborder={0 0 0}}
     </xsl:text>
     <xsl:if test="$parStylevSpace != '0'">
       <xsl:text>\setlength{\parskip}{</xsl:text>
@@ -295,10 +297,10 @@
     
     <xsl:text>
       \title{</xsl:text>
-    <xsl:apply-templates select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/>
+    <xsl:value-of select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/>
     <xsl:text>}
       \author{</xsl:text>
-    <xsl:apply-templates select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/>
+    <xsl:value-of select="//tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/>
     <xsl:text>}
       \date{}
     </xsl:text>


### PR DESCRIPTION
Removes all formatting controls into the preamble. ~~I haven't yet had time to reimplement customizable formatting for `\maketitle`; this is most easily done via the [`titling`](https://ctan.org/pkg/titling) package, but if used it would probably be best to only insert overrides conditionally.~~

This creates a command called `\TEIsection` for the headings, since `\ledsection` is broken right now, but eventually this should be changed. Ideally, there should also be `\TEIsubsection` etc. for nested headings.